### PR TITLE
Structured errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/mitchellh/mapstructure
+module github.com/mobiledgex/mapstructure
 
 go 1.14

--- a/mapstructure.go
+++ b/mapstructure.go
@@ -524,7 +524,7 @@ func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) er
 		if err == nil {
 			val.SetInt(i)
 		} else {
-			return fmt.Errorf("cannot parse '%s' as int: %s", name, err)
+			return fmt.Errorf("cannot xxx parse '%s' as int: %s", name, err)
 		}
 	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
 		jn := data.(json.Number)


### PR DESCRIPTION
Changes some of the errors into structured errors, so the caller can format the error messages as desired. The original error messages remain unchanged when converting the error to a string.